### PR TITLE
chore: Add "other" entry for PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,7 +7,7 @@
 - [ ] Refactor
 - [ ] Breaking Change
 - [ ] Documentation
-- [ ] Other (CI, chores)
+- [ ] Other (CI, chores, etc.)
 
 ## Rationale / Problems Fixed
 <!--- Give us more information about why you think this PR is needed, or what problems it fixes -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,6 +7,7 @@
 - [ ] Refactor
 - [ ] Breaking Change
 - [ ] Documentation
+- [ ] Other (CI, chores)
 
 ## Rationale / Problems Fixed
 <!--- Give us more information about why you think this PR is needed, or what problems it fixes -->


### PR DESCRIPTION
Some PR's I have been opening for CI and other stuff aren't really falling in any of the available options for the PR template.

Proposing to add an "Other" type to the template that we can use in those situations. 

I suppose the alternative would be to not check any of the available options?